### PR TITLE
[Home] HomPage UI 구현 

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,6 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp();
+    return MaterialApp(themeMode: ThemeMode.dark);
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:movie_info_app/theme/dark_theme.dart';
+import 'package:movie_info_app/ui/pages/home/home_page.dart';
 
 void main() {
   runApp(ProviderScope(child: MyApp()));
@@ -10,6 +12,10 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(themeMode: ThemeMode.dark);
+    return MaterialApp(
+      themeMode: ThemeMode.dark,
+      darkTheme: darkTheme,
+      home: HomePage(),
+    );
   }
 }

--- a/lib/theme/dark_theme.dart
+++ b/lib/theme/dark_theme.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+final ThemeData darkTheme = ThemeData(
+  brightness: Brightness.dark,
+  primarySwatch: Colors.deepPurple,
+  scaffoldBackgroundColor: Colors.black,
+  appBarTheme: const AppBarTheme(
+    backgroundColor: Colors.black87,
+    foregroundColor: Colors.white,
+  ),
+  textTheme: const TextTheme(
+    bodyLarge: TextStyle(color: Colors.white),
+    bodyMedium: TextStyle(color: Colors.white),
+  ),
+);

--- a/lib/ui/pages/detail/detail_page.dart
+++ b/lib/ui/pages/detail/detail_page.dart
@@ -1,1 +1,24 @@
+import 'package:flutter/material.dart';
 
+class DetailPage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: Column(
+        children: [
+          Hero(
+            tag: 'sample_image',
+            child: AspectRatio(
+              aspectRatio: 1,
+              child: Image.network(
+                'https://picsum.photos/200/300',
+                fit: BoxFit.cover,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/detail/detail_page.dart
+++ b/lib/ui/pages/detail/detail_page.dart
@@ -13,6 +13,7 @@ class DetailPage extends StatelessWidget {
               aspectRatio: 1,
               child: Image.network(
                 'https://picsum.photos/200/300',
+                width: double.infinity,
                 fit: BoxFit.cover,
               ),
             ),

--- a/lib/ui/pages/home/home_page.dart
+++ b/lib/ui/pages/home/home_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:movie_info_app/ui/pages/detail/detail_page.dart';
 
 class HomePage extends StatelessWidget {
   @override
@@ -18,14 +19,28 @@ class HomePage extends StatelessWidget {
                     style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
                   ),
                 ),
-                Padding(
-                  padding: const EdgeInsets.all(15),
-                  child: ClipRRect(
-                    borderRadius: BorderRadius.circular(10),
-                    child: Image.network(
-                      'https://picsum.photos/200/300',
-                      width: double.infinity,
-                      fit: BoxFit.cover,
+                GestureDetector(
+                  onTap: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (context) {
+                          return DetailPage();
+                        },
+                      ),
+                    );
+                  },
+                  child: Padding(
+                    padding: const EdgeInsets.all(15),
+                    child: Hero(
+                      tag: 'sample_image',
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(10),
+                        child: Image.network(
+                          'https://picsum.photos/200/300',
+                          width: double.infinity,
+                          fit: BoxFit.cover,
+                        ),
+                      ),
                     ),
                   ),
                 ),

--- a/lib/ui/pages/home/home_page.dart
+++ b/lib/ui/pages/home/home_page.dart
@@ -86,32 +86,30 @@ class HomePage extends StatelessWidget {
                         itemBuilder: (context, index) {
                           return Padding(
                             padding: const EdgeInsets.only(left: 30),
-                            child: ClipRRect(
-                              borderRadius: BorderRadius.circular(15),
-                              child: Stack(
-                                // 텍스트가 이미지 바깥까지 나올 수 있게 함
-                                clipBehavior: Clip.none,
-                                children: [
-                                  Image.network(
+                            child: Stack(
+                              // 텍스트가 이미지 바깥까지 나올 수 있게 함
+                              clipBehavior: Clip.none,
+                              children: [
+                                ClipRRect(
+                                  borderRadius: BorderRadius.circular(15),
+                                  child: Image.network(
                                     'https://picsum.photos/200/300',
                                     fit: BoxFit.cover,
                                   ),
-                                  Positioned(
-                                    bottom: -15,
-                                    left: -25,
-                                    child: Container(
-                                      child: Text(
-                                        '1',
-                                        style: TextStyle(
-                                          color: Colors.white,
-                                          fontSize: 80,
-                                          fontWeight: FontWeight.bold,
-                                        ),
-                                      ),
+                                ),
+                                Positioned(
+                                  bottom: -15,
+                                  left: -30,
+                                  child: Text(
+                                    '${index + 1}',
+                                    style: TextStyle(
+                                      color: Colors.white,
+                                      fontSize: 80,
+                                      fontWeight: FontWeight.bold,
                                     ),
                                   ),
-                                ],
-                              ),
+                                ),
+                              ],
                             ),
                           );
                         },
@@ -127,7 +125,7 @@ class HomePage extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Padding(
-                      padding: const EdgeInsets.only(left: 10),
+                      padding: const EdgeInsets.all(10),
                       child: Text(
                         '평점 높은 순',
                         style: TextStyle(
@@ -142,7 +140,7 @@ class HomePage extends StatelessWidget {
                         itemCount: 20,
                         itemBuilder: (context, index) {
                           return Padding(
-                            padding: const EdgeInsets.all(3),
+                            padding: const EdgeInsets.only(left: 10),
                             child: ClipRRect(
                               borderRadius: BorderRadius.circular(15),
                               child: Image.network(

--- a/lib/ui/pages/home/home_page.dart
+++ b/lib/ui/pages/home/home_page.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+class HomePage extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: ListView(
+          children: [
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Padding(
+                  padding: const EdgeInsets.only(left: 10),
+                  child: Text(
+                    '가장 인기있는',
+                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.all(15),
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(10),
+                    child: Image.network(
+                      'https://picsum.photos/200/300',
+                      width: double.infinity,
+                      fit: BoxFit.cover,
+                    ),
+                  ),
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(10),
+                      child: Text(
+                        '현재 상영중',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 20,
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      height: 180,
+                      child: ListView.separated(
+                        itemCount: 20,
+                        itemBuilder: (context, index) {
+                          return Padding(
+                            padding: const EdgeInsets.only(left: 10),
+                            child: ClipRRect(
+                              borderRadius: BorderRadius.circular(15),
+                              child: Image.network(
+                                'https://picsum.photos/200/300',
+                                fit: BoxFit.cover,
+                              ),
+                            ),
+                          );
+                        },
+                        separatorBuilder: (context, index) {
+                          return SizedBox(width: 5);
+                        },
+                        scrollDirection: Axis.horizontal,
+                      ),
+                    ),
+                  ],
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(10),
+                      child: Text(
+                        '인기순',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 20,
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      height: 180,
+                      child: ListView.separated(
+                        itemCount: 20,
+                        itemBuilder: (context, index) {
+                          return Padding(
+                            padding: const EdgeInsets.only(left: 30),
+                            child: ClipRRect(
+                              borderRadius: BorderRadius.circular(15),
+                              child: Stack(
+                                // 텍스트가 이미지 바깥까지 나올 수 있게 함
+                                clipBehavior: Clip.none,
+                                children: [
+                                  Image.network(
+                                    'https://picsum.photos/200/300',
+                                    fit: BoxFit.cover,
+                                  ),
+                                  Positioned(
+                                    bottom: -15,
+                                    left: -25,
+                                    child: Container(
+                                      child: Text(
+                                        '1',
+                                        style: TextStyle(
+                                          color: Colors.white,
+                                          fontSize: 80,
+                                          fontWeight: FontWeight.bold,
+                                        ),
+                                      ),
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          );
+                        },
+                        separatorBuilder: (context, index) {
+                          return SizedBox(width: 5);
+                        },
+                        scrollDirection: Axis.horizontal,
+                      ),
+                    ),
+                  ],
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.only(left: 10),
+                      child: Text(
+                        '평점 높은 순',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 20,
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      height: 180,
+                      child: ListView.separated(
+                        itemCount: 20,
+                        itemBuilder: (context, index) {
+                          return Padding(
+                            padding: const EdgeInsets.all(3),
+                            child: ClipRRect(
+                              borderRadius: BorderRadius.circular(15),
+                              child: Image.network(
+                                'https://picsum.photos/200/300',
+                                fit: BoxFit.cover,
+                              ),
+                            ),
+                          );
+                        },
+                        separatorBuilder: (context, index) {
+                          return SizedBox(width: 5);
+                        },
+                        scrollDirection: Axis.horizontal,
+                      ),
+                    ),
+                  ],
+                ),
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Padding(
+                      padding: const EdgeInsets.all(10),
+                      child: Text(
+                        '개봉예정',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          fontSize: 20,
+                        ),
+                      ),
+                    ),
+                    SizedBox(
+                      height: 180,
+                      child: ListView.separated(
+                        itemCount: 20,
+                        itemBuilder: (context, index) {
+                          return Padding(
+                            padding: const EdgeInsets.only(left: 10),
+                            child: ClipRRect(
+                              borderRadius: BorderRadius.circular(15),
+                              child: Image.network(
+                                'https://picsum.photos/200/300',
+                                fit: BoxFit.cover,
+                              ),
+                            ),
+                          );
+                        },
+                        separatorBuilder: (context, index) {
+                          return SizedBox(width: 5);
+                        },
+                        scrollDirection: Axis.horizontal,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
### 🚀 개요
HomPage UI 구현 

### 🔧 변경사항
- 디폴트 다크모드로 하고 라이트모드 지원 X
- 가장 인기있는 영화 이미지는 패딩 20 제외 가로 너비 모두 차지
- 가로방향 리스트뷰로 현재 상영중 인기순 평점 높은순 개봉예정 이미지 20개씩 출력하고 각 리스트뷰의 높이는 180으로 지정
- 각각의 리스트뷰 위 라벨 출력(현재 상영중 인기순 평점 높은순 개봉예정)
- 인기순 이미지 출력 시 랭킹 숫자 이미지 위 좌측하단에 출력

### 실행 화면
<img src="https://github.com/user-attachments/assets/3cca5f24-efd4-46aa-ba88-0804cf5929f0" width="300" height="600"/>
<img src="https://github.com/user-attachments/assets/8970a51f-ed94-4d7b-9e45-d579beff76bb" width="300" height="600"/>
