### PR TITLE
Dlworua/issue5

### DIFF
--- a/lib/ui/pages/detail/detail_page.dart
+++ b/lib/ui/pages/detail/detail_page.dart
@@ -345,131 +345,51 @@ class DetailPage extends StatelessWidget {
                   Container(
                     width: 150,
                     margin: EdgeInsets.all(8),
-                    decoration: BoxDecoration(color: Colors.blue[900]),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          '주말관객',
-                          style: TextStyle(
-                            color: Colors.grey[400],
-                            fontSize: 14,
-                          ),
-                        ),
-                        SizedBox(height: 5),
-                        Text(
-                          '567,890',
-                          style: TextStyle(
-                            color: Colors.white,
-                            fontSize: 18,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ],
+                    decoration: BoxDecoration(
+                      image: DecorationImage(
+                        image: NetworkImage('https://picsum.photos/200/300'),
+                        fit: BoxFit.cover,
+                      ),
                     ),
                   ),
                   Container(
                     width: 150,
                     margin: EdgeInsets.all(8),
-                    decoration: BoxDecoration(color: Colors.blue[900]),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          '주말매출',
-                          style: TextStyle(
-                            color: Colors.grey[400],
-                            fontSize: 14,
-                          ),
-                        ),
-                        SizedBox(height: 5),
-                        Text(
-                          '5,678,901',
-                          style: TextStyle(
-                            color: Colors.white,
-                            fontSize: 18,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ],
+                    decoration: BoxDecoration(
+                      image: DecorationImage(
+                        image: NetworkImage('https://picsum.photos/200/301'),
+                        fit: BoxFit.cover,
+                      ),
                     ),
                   ),
                   Container(
                     width: 150,
                     margin: EdgeInsets.all(8),
-                    decoration: BoxDecoration(color: Colors.blue[900]),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          '누적관객',
-                          style: TextStyle(
-                            color: Colors.grey[400],
-                            fontSize: 14,
-                          ),
-                        ),
-                        SizedBox(height: 5),
-                        Text(
-                          '2,345,678',
-                          style: TextStyle(
-                            color: Colors.white,
-                            fontSize: 18,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ],
+                    decoration: BoxDecoration(
+                      image: DecorationImage(
+                        image: NetworkImage('https://picsum.photos/200/302'),
+                        fit: BoxFit.cover,
+                      ),
                     ),
                   ),
                   Container(
                     width: 150,
                     margin: EdgeInsets.all(8),
-                    decoration: BoxDecoration(color: Colors.blue[900]),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          '누적매출',
-                          style: TextStyle(
-                            color: Colors.grey[400],
-                            fontSize: 14,
-                          ),
-                        ),
-                        SizedBox(height: 5),
-                        Text(
-                          '23,456,789',
-                          style: TextStyle(
-                            color: Colors.white,
-                            fontSize: 18,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ],
+                    decoration: BoxDecoration(
+                      image: DecorationImage(
+                        image: NetworkImage('https://picsum.photos/200/303'),
+                        fit: BoxFit.cover,
+                      ),
                     ),
                   ),
                   Container(
                     width: 150,
                     margin: EdgeInsets.all(8),
-                    decoration: BoxDecoration(color: Colors.blue[900]),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Text(
-                          '순위',
-                          style: TextStyle(
-                            color: Colors.grey[400],
-                            fontSize: 14,
-                          ),
-                        ),
-                        SizedBox(height: 5),
-                        Text(
-                          '1위',
-                          style: TextStyle(
-                            color: Colors.white,
-                            fontSize: 18,
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                      ],
+                    decoration: BoxDecoration(
+                      image: DecorationImage(
+                        image: NetworkImage('https://picsum.photos/200/304'),
+                        fit: BoxFit.cover,
+                      ),
                     ),
                   ),
                 ],

--- a/lib/ui/pages/detail/detail_page.dart
+++ b/lib/ui/pages/detail/detail_page.dart
@@ -161,7 +161,10 @@ class DetailPage extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.only(left: 10, right: 10),
               child: Text(
-                'After a long time, Moana and her friends are back in the ocean. Moana is now a grown-up and has a daughter named Mele. Moana and her friends are back in the ocean. Moana is now a grown-up and has a daughter named Mele.',
+                '''After a long time, Moana and her friends are back in the ocean.
+                 Moana is now a grown-up and has a daughter named Mele.
+                 Moana and her friends are back in the ocean.
+                 Moana is now a grown-up and has a daughter named Mele.''',
                 style: TextStyle(
                   fontSize: 15,
                   fontWeight: FontWeight.w600,

--- a/lib/ui/pages/detail/detail_page.dart
+++ b/lib/ui/pages/detail/detail_page.dart
@@ -27,14 +27,14 @@ class DetailPage extends StatelessWidget {
               ),
             ),
             Padding(
-              padding: const EdgeInsets.fromLTRB(10, 20, 20, 10),
+              padding: const EdgeInsets.fromLTRB(10, 20, 20, 5),
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Row(
                     children: [
                       Text(
-                        '영화이름',
+                        'Moana 2',
                         style: TextStyle(
                           fontSize: 25,
                           fontWeight: FontWeight.bold,
@@ -42,7 +42,7 @@ class DetailPage extends StatelessWidget {
                       ),
                       Spacer(),
                       Text(
-                        '개봉일',
+                        '2024-11-27',
                         style: TextStyle(
                           fontWeight: FontWeight.bold,
                           color: Colors.grey,
@@ -52,14 +52,428 @@ class DetailPage extends StatelessWidget {
                     ],
                   ),
                   SizedBox(height: 5),
-                  Text('태그라인', style: TextStyle(height: 1.5, fontSize: 15)),
-                  Text('러닝타임', style: TextStyle(fontSize: 15)),
+                  Text(
+                    'The ocean is calling them back.',
+                    style: TextStyle(
+                      height: 1.5,
+                      fontSize: 18,
+                      color: Colors.grey[400],
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  Text(
+                    '100분',
+                    style: TextStyle(
+                      fontSize: 18,
+                      color: Colors.grey[400],
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
                 ],
               ),
             ),
             Padding(
-              padding: const EdgeInsets.only(left: 10, right: 10),
+              padding: const EdgeInsets.fromLTRB(10, 0, 10, 0),
               child: Divider(color: Colors.grey[100], thickness: 0.5),
+            ),
+            Container(
+              height: 50,
+              padding: EdgeInsets.only(top: 5, left: 10),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  Container(
+                    padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    decoration: BoxDecoration(
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(25),
+                      border: Border.all(color: Colors.white, width: 1),
+                    ),
+                    child: Center(
+                      child: Text(
+                        'Animation',
+                        style: TextStyle(
+                          color: Colors.blue,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    decoration: BoxDecoration(
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(25),
+                      border: Border.all(color: Colors.white, width: 1),
+                    ),
+                    child: Center(
+                      child: Text(
+                        'Adventure',
+                        style: TextStyle(
+                          color: Colors.blue,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    decoration: BoxDecoration(
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(25),
+                      border: Border.all(color: Colors.white, width: 1),
+                    ),
+                    child: Center(
+                      child: Text(
+                        'Family',
+                        style: TextStyle(
+                          color: Colors.blue,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                  Container(
+                    padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                    decoration: BoxDecoration(
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(25),
+                      border: Border.all(color: Colors.white, width: 1),
+                    ),
+                    child: Center(
+                      child: Text(
+                        'Fantasy',
+                        style: TextStyle(
+                          color: Colors.blue,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(10, 5, 10, 5),
+              child: Divider(color: Colors.grey[100], thickness: 0.5),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(left: 10, right: 10),
+              child: Text(
+                'After a long time, Moana and her friends are back in the ocean. Moana is now a grown-up and has a daughter named Mele. Moana and her friends are back in the ocean. Moana is now a grown-up and has a daughter named Mele.',
+                style: TextStyle(
+                  fontSize: 15,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.grey[400],
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.fromLTRB(10, 5, 10, 5),
+              child: Divider(color: Colors.grey[100], thickness: 0.5),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(left: 10, right: 10),
+              child: Text(
+                '흥행 정보',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w600,
+                  color: Colors.white,
+                ),
+              ),
+            ),
+            Container(
+              height: 100,
+              child: ListView(
+                scrollDirection: Axis.horizontal,
+                children: [
+                  Container(
+                    width: 150,
+                    margin: EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[800],
+                      borderRadius: BorderRadius.circular(15),
+                    ),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          '관객수',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                        ),
+                        SizedBox(height: 5),
+                        Text(
+                          '1,234,567',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Container(
+                    width: 150,
+                    margin: EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[800],
+                      borderRadius: BorderRadius.circular(15),
+                    ),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          '매출액',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                        ),
+                        SizedBox(height: 5),
+                        Text(
+                          '12,345,678',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Container(
+                    width: 150,
+                    margin: EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[800],
+                      borderRadius: BorderRadius.circular(15),
+                    ),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          '스크린수',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                        ),
+                        SizedBox(height: 5),
+                        Text(
+                          '789',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Container(
+                    width: 150,
+                    margin: EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[800],
+                      borderRadius: BorderRadius.circular(15),
+                    ),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          '상영횟수',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                        ),
+                        SizedBox(height: 5),
+                        Text(
+                          '3,456',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Container(
+                    width: 150,
+                    margin: EdgeInsets.all(8),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[800],
+                      borderRadius: BorderRadius.circular(15),
+                    ),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          '평점',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                        ),
+                        SizedBox(height: 5),
+                        Text(
+                          '9.5',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Container(
+              height: 100,
+              child: ListView(
+                scrollDirection: Axis.horizontal,
+                children: [
+                  Container(
+                    width: 150,
+                    margin: EdgeInsets.all(8),
+                    decoration: BoxDecoration(color: Colors.blue[900]),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          '주말관객',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                        ),
+                        SizedBox(height: 5),
+                        Text(
+                          '567,890',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Container(
+                    width: 150,
+                    margin: EdgeInsets.all(8),
+                    decoration: BoxDecoration(color: Colors.blue[900]),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          '주말매출',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                        ),
+                        SizedBox(height: 5),
+                        Text(
+                          '5,678,901',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Container(
+                    width: 150,
+                    margin: EdgeInsets.all(8),
+                    decoration: BoxDecoration(color: Colors.blue[900]),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          '누적관객',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                        ),
+                        SizedBox(height: 5),
+                        Text(
+                          '2,345,678',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Container(
+                    width: 150,
+                    margin: EdgeInsets.all(8),
+                    decoration: BoxDecoration(color: Colors.blue[900]),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          '누적매출',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                        ),
+                        SizedBox(height: 5),
+                        Text(
+                          '23,456,789',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  Container(
+                    width: 150,
+                    margin: EdgeInsets.all(8),
+                    decoration: BoxDecoration(color: Colors.blue[900]),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          '순위',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                        ),
+                        SizedBox(height: 5),
+                        Text(
+                          '1위',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 18,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
             ),
           ],
         ),

--- a/lib/ui/pages/detail/detail_page.dart
+++ b/lib/ui/pages/detail/detail_page.dart
@@ -201,19 +201,18 @@ class DetailPage extends StatelessWidget {
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         Text(
-                          '관객수',
-                          style: TextStyle(
-                            color: Colors.grey[400],
-                            fontSize: 14,
-                          ),
-                        ),
-                        SizedBox(height: 5),
-                        Text(
                           '1,234,567',
                           style: TextStyle(
                             color: Colors.grey,
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        Text(
+                          '관객수',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
                           ),
                         ),
                       ],
@@ -230,14 +229,6 @@ class DetailPage extends StatelessWidget {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Text(
-                          '매출액',
-                          style: TextStyle(
-                            color: Colors.grey[400],
-                            fontSize: 14,
-                          ),
-                        ),
-                        SizedBox(height: 5),
                         Text(
                           '12,345,678',
                           style: TextStyle(
@@ -246,6 +237,13 @@ class DetailPage extends StatelessWidget {
                             fontWeight: FontWeight.bold,
                           ),
                         ),
+                        Text(
+                          '매출액',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                        ),
                       ],
                     ),
                   ),
@@ -260,14 +258,6 @@ class DetailPage extends StatelessWidget {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Text(
-                          '스크린수',
-                          style: TextStyle(
-                            color: Colors.grey[400],
-                            fontSize: 14,
-                          ),
-                        ),
-                        SizedBox(height: 5),
                         Text(
                           '789',
                           style: TextStyle(
@@ -276,6 +266,13 @@ class DetailPage extends StatelessWidget {
                             fontWeight: FontWeight.bold,
                           ),
                         ),
+                        Text(
+                          '스크린수',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                        ),
                       ],
                     ),
                   ),
@@ -290,14 +287,6 @@ class DetailPage extends StatelessWidget {
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Text(
-                          '상영횟수',
-                          style: TextStyle(
-                            color: Colors.grey[400],
-                            fontSize: 14,
-                          ),
-                        ),
-                        SizedBox(height: 5),
                         Text(
                           '3,456',
                           style: TextStyle(
@@ -306,6 +295,13 @@ class DetailPage extends StatelessWidget {
                             fontWeight: FontWeight.bold,
                           ),
                         ),
+                        Text(
+                          '상영횟수',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
+                          ),
+                        ),
                       ],
                     ),
                   ),
@@ -321,19 +317,18 @@ class DetailPage extends StatelessWidget {
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
                         Text(
-                          '평점',
-                          style: TextStyle(
-                            color: Colors.grey[400],
-                            fontSize: 14,
-                          ),
-                        ),
-                        SizedBox(height: 5),
-                        Text(
                           '9.5',
                           style: TextStyle(
                             color: Colors.grey,
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        Text(
+                          '평점',
+                          style: TextStyle(
+                            color: Colors.grey[400],
+                            fontSize: 14,
                           ),
                         ),
                       ],

--- a/lib/ui/pages/detail/detail_page.dart
+++ b/lib/ui/pages/detail/detail_page.dart
@@ -349,7 +349,7 @@ class DetailPage extends StatelessWidget {
                 scrollDirection: Axis.horizontal,
                 children: [
                   Container(
-                    width: 150,
+                    width: 200,
                     margin: EdgeInsets.all(8),
                     decoration: BoxDecoration(
                       image: DecorationImage(
@@ -359,7 +359,7 @@ class DetailPage extends StatelessWidget {
                     ),
                   ),
                   Container(
-                    width: 150,
+                    width: 200,
                     margin: EdgeInsets.all(8),
                     decoration: BoxDecoration(
                       image: DecorationImage(
@@ -369,7 +369,7 @@ class DetailPage extends StatelessWidget {
                     ),
                   ),
                   Container(
-                    width: 150,
+                    width: 200,
                     margin: EdgeInsets.all(8),
                     decoration: BoxDecoration(
                       image: DecorationImage(
@@ -379,7 +379,7 @@ class DetailPage extends StatelessWidget {
                     ),
                   ),
                   Container(
-                    width: 150,
+                    width: 200,
                     margin: EdgeInsets.all(8),
                     decoration: BoxDecoration(
                       image: DecorationImage(
@@ -389,7 +389,7 @@ class DetailPage extends StatelessWidget {
                     ),
                   ),
                   Container(
-                    width: 150,
+                    width: 200,
                     margin: EdgeInsets.all(8),
                     decoration: BoxDecoration(
                       image: DecorationImage(

--- a/lib/ui/pages/detail/detail_page.dart
+++ b/lib/ui/pages/detail/detail_page.dart
@@ -88,7 +88,7 @@ class DetailPage extends StatelessWidget {
                     decoration: BoxDecoration(
                       color: Colors.transparent,
                       borderRadius: BorderRadius.circular(25),
-                      border: Border.all(color: Colors.white, width: 1),
+                      border: Border.all(color: Colors.grey, width: 1),
                     ),
                     child: Center(
                       child: Text(
@@ -105,7 +105,7 @@ class DetailPage extends StatelessWidget {
                     decoration: BoxDecoration(
                       color: Colors.transparent,
                       borderRadius: BorderRadius.circular(25),
-                      border: Border.all(color: Colors.white, width: 1),
+                      border: Border.all(color: Colors.grey, width: 1),
                     ),
                     child: Center(
                       child: Text(
@@ -122,7 +122,7 @@ class DetailPage extends StatelessWidget {
                     decoration: BoxDecoration(
                       color: Colors.transparent,
                       borderRadius: BorderRadius.circular(25),
-                      border: Border.all(color: Colors.white, width: 1),
+                      border: Border.all(color: Colors.grey, width: 1),
                     ),
                     child: Center(
                       child: Text(
@@ -139,7 +139,7 @@ class DetailPage extends StatelessWidget {
                     decoration: BoxDecoration(
                       color: Colors.transparent,
                       borderRadius: BorderRadius.circular(25),
-                      border: Border.all(color: Colors.white, width: 1),
+                      border: Border.all(color: Colors.grey, width: 1),
                     ),
                     child: Center(
                       child: Text(
@@ -190,11 +190,12 @@ class DetailPage extends StatelessWidget {
                 scrollDirection: Axis.horizontal,
                 children: [
                   Container(
-                    width: 150,
+                    padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                     margin: EdgeInsets.all(8),
                     decoration: BoxDecoration(
-                      color: Colors.grey[800],
-                      borderRadius: BorderRadius.circular(15),
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(color: Colors.grey, width: 1),
                     ),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -210,7 +211,7 @@ class DetailPage extends StatelessWidget {
                         Text(
                           '1,234,567',
                           style: TextStyle(
-                            color: Colors.white,
+                            color: Colors.grey,
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
                           ),
@@ -219,11 +220,12 @@ class DetailPage extends StatelessWidget {
                     ),
                   ),
                   Container(
-                    width: 150,
+                    padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                     margin: EdgeInsets.all(8),
                     decoration: BoxDecoration(
-                      color: Colors.grey[800],
-                      borderRadius: BorderRadius.circular(15),
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(color: Colors.grey, width: 1),
                     ),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -239,7 +241,7 @@ class DetailPage extends StatelessWidget {
                         Text(
                           '12,345,678',
                           style: TextStyle(
-                            color: Colors.white,
+                            color: Colors.grey,
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
                           ),
@@ -248,11 +250,12 @@ class DetailPage extends StatelessWidget {
                     ),
                   ),
                   Container(
-                    width: 150,
+                    padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                     margin: EdgeInsets.all(8),
                     decoration: BoxDecoration(
-                      color: Colors.grey[800],
-                      borderRadius: BorderRadius.circular(15),
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(color: Colors.grey, width: 1),
                     ),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -268,7 +271,7 @@ class DetailPage extends StatelessWidget {
                         Text(
                           '789',
                           style: TextStyle(
-                            color: Colors.white,
+                            color: Colors.grey,
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
                           ),
@@ -277,11 +280,12 @@ class DetailPage extends StatelessWidget {
                     ),
                   ),
                   Container(
-                    width: 150,
+                    padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                     margin: EdgeInsets.all(8),
                     decoration: BoxDecoration(
-                      color: Colors.grey[800],
-                      borderRadius: BorderRadius.circular(15),
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(color: Colors.grey, width: 1),
                     ),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -297,7 +301,7 @@ class DetailPage extends StatelessWidget {
                         Text(
                           '3,456',
                           style: TextStyle(
-                            color: Colors.white,
+                            color: Colors.grey,
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
                           ),
@@ -306,11 +310,12 @@ class DetailPage extends StatelessWidget {
                     ),
                   ),
                   Container(
-                    width: 150,
+                    padding: EdgeInsets.symmetric(horizontal: 12, vertical: 8),
                     margin: EdgeInsets.all(8),
                     decoration: BoxDecoration(
-                      color: Colors.grey[800],
-                      borderRadius: BorderRadius.circular(15),
+                      color: Colors.transparent,
+                      borderRadius: BorderRadius.circular(10),
+                      border: Border.all(color: Colors.grey, width: 1),
                     ),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
@@ -326,7 +331,7 @@ class DetailPage extends StatelessWidget {
                         Text(
                           '9.5',
                           style: TextStyle(
-                            color: Colors.white,
+                            color: Colors.grey,
                             fontSize: 18,
                             fontWeight: FontWeight.bold,
                           ),
@@ -337,8 +342,9 @@ class DetailPage extends StatelessWidget {
                 ],
               ),
             ),
+            SizedBox(height: 10),
             Container(
-              height: 100,
+              height: 130,
               child: ListView(
                 scrollDirection: Axis.horizontal,
                 children: [

--- a/lib/ui/pages/detail/detail_page.dart
+++ b/lib/ui/pages/detail/detail_page.dart
@@ -161,10 +161,7 @@ class DetailPage extends StatelessWidget {
             Padding(
               padding: const EdgeInsets.only(left: 10, right: 10),
               child: Text(
-                '''After a long time, Moana and her friends are back in the ocean.
-                 Moana is now a grown-up and has a daughter named Mele.
-                 Moana and her friends are back in the ocean.
-                 Moana is now a grown-up and has a daughter named Mele.''',
+                'After a long time, Moana and her friends are back in the ocean. Moana is now a grown-up and has a daughter named Mele. Moana and her friends are back in the ocean. Moana is now a grown-up and has a daughter named Mele.',
                 style: TextStyle(
                   fontSize: 15,
                   fontWeight: FontWeight.w600,

--- a/lib/ui/pages/detail/detail_page.dart
+++ b/lib/ui/pages/detail/detail_page.dart
@@ -51,7 +51,7 @@ class DetailPage extends StatelessWidget {
                       ),
                     ],
                   ),
-                  SizedBox(height: 10),
+                  SizedBox(height: 5),
                   Text('태그라인', style: TextStyle(height: 1.5, fontSize: 15)),
                   Text('러닝타임', style: TextStyle(fontSize: 15)),
                 ],

--- a/lib/ui/pages/detail/detail_page.dart
+++ b/lib/ui/pages/detail/detail_page.dart
@@ -1,24 +1,68 @@
 import 'package:flutter/material.dart';
 
 class DetailPage extends StatelessWidget {
+  final String tag;
+
+  const DetailPage({super.key, required this.tag});
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(),
-      body: Column(
-        children: [
-          Hero(
-            tag: 'sample_image',
-            child: AspectRatio(
-              aspectRatio: 1,
-              child: Image.network(
-                'https://picsum.photos/200/300',
-                width: double.infinity,
-                fit: BoxFit.cover,
+      body: SafeArea(
+        child: ListView(
+          children: [
+            Hero(
+              tag: tag,
+              child: ClipRRect(
+                borderRadius: BorderRadius.circular(10),
+                child: AspectRatio(
+                  aspectRatio: 1,
+                  child: Image.network(
+                    'https://picsum.photos/200/300',
+                    width: double.infinity,
+                    fit: BoxFit.cover,
+                  ),
+                ),
               ),
             ),
-          ),
-        ],
+            Padding(
+              padding: const EdgeInsets.fromLTRB(10, 20, 20, 10),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Text(
+                        '영화이름',
+                        style: TextStyle(
+                          fontSize: 25,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      Spacer(),
+                      Text(
+                        '개봉일',
+                        style: TextStyle(
+                          fontWeight: FontWeight.bold,
+                          color: Colors.grey,
+                          fontSize: 15,
+                        ),
+                      ),
+                    ],
+                  ),
+                  SizedBox(height: 10),
+                  Text('태그라인', style: TextStyle(height: 1.5, fontSize: 15)),
+                  Text('러닝타임', style: TextStyle(fontSize: 15)),
+                ],
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.only(left: 10, right: 10),
+              child: Divider(color: Colors.grey[100], thickness: 0.5),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/ui/pages/home/home_page.dart
+++ b/lib/ui/pages/home/home_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter/widgets.dart';
 import 'package:movie_info_app/ui/pages/detail/detail_page.dart';
 
 class HomePage extends StatelessWidget {
+  const HomePage({super.key});
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -24,7 +26,7 @@ class HomePage extends StatelessWidget {
                     Navigator.of(context).push(
                       MaterialPageRoute(
                         builder: (context) {
-                          return DetailPage();
+                          return DetailPage(tag: 'sample_image1');
                         },
                       ),
                     );
@@ -32,7 +34,7 @@ class HomePage extends StatelessWidget {
                   child: Padding(
                     padding: const EdgeInsets.all(15),
                     child: Hero(
-                      tag: 'sample_image',
+                      tag: 'sample_image1',
                       child: ClipRRect(
                         borderRadius: BorderRadius.circular(10),
                         child: Image.network(
@@ -71,13 +73,15 @@ class HomePage extends StatelessWidget {
                                   Navigator.of(context).push(
                                     MaterialPageRoute(
                                       builder: (context) {
-                                        return DetailPage();
+                                        return DetailPage(
+                                          tag: 'sample_image2 $index',
+                                        );
                                       },
                                     ),
                                   );
                                 },
                                 child: Hero(
-                                  tag: 'sample_image',
+                                  tag: 'sample_image2 $index',
                                   child: Image.network(
                                     'https://picsum.photos/200/300',
                                     fit: BoxFit.cover,
@@ -124,13 +128,15 @@ class HomePage extends StatelessWidget {
                                     Navigator.of(context).push(
                                       MaterialPageRoute(
                                         builder: (context) {
-                                          return DetailPage();
+                                          return DetailPage(
+                                            tag: 'sample_image3 $index',
+                                          );
                                         },
                                       ),
                                     );
                                   },
                                   child: Hero(
-                                    tag: 'sample_image',
+                                    tag: 'sample_image3 $index',
                                     child: ClipRRect(
                                       borderRadius: BorderRadius.circular(15),
                                       child: Image.network(
@@ -189,13 +195,15 @@ class HomePage extends StatelessWidget {
                                 Navigator.of(context).push(
                                   MaterialPageRoute(
                                     builder: (context) {
-                                      return DetailPage();
+                                      return DetailPage(
+                                        tag: 'sample_image4 $index',
+                                      );
                                     },
                                   ),
                                 );
                               },
                               child: Hero(
-                                tag: 'sample_image',
+                                tag: 'sample_image4 $index',
                                 child: ClipRRect(
                                   borderRadius: BorderRadius.circular(15),
                                   child: Image.network(
@@ -240,13 +248,15 @@ class HomePage extends StatelessWidget {
                                 Navigator.of(context).push(
                                   MaterialPageRoute(
                                     builder: (context) {
-                                      return DetailPage();
+                                      return DetailPage(
+                                        tag: 'sample_image5 $index',
+                                      );
                                     },
                                   ),
                                 );
                               },
                               child: Hero(
-                                tag: 'sample_image',
+                                tag: 'sample_image5 $index',
                                 child: ClipRRect(
                                   borderRadius: BorderRadius.circular(15),
                                   child: Image.network(


### PR DESCRIPTION


[Detail] DetailPage UI 구현


내용

### 🚀 개요
DetailPage UI 구현한다.

### 🔧 변경사항
- 이미지는 가로 너비 모두 차지
- 아래에 출력되는 정보
    - `영화 제목` `개봉일`
    - `태그라인`
    - `러닝타임`
    - `카테고리` 들
    - `영화설명`
    - `평점` `평점투표수` `인기점수` `예산` `수익` 가로 리스트뷰
 - `제작사` 이미지 가로 리스트뷰(배경 흰색, 투명도 0.9)
### 실행 화면
<img src="https://github.com/user-attachments/assets/89664e14-9255-49be-9b78-8f7132698e6d" width="300" height="600"/>
<img src="https://github.com/user-attachments/assets/0117ea3e-affa-4f20-8aea-1c1f30b5641e" width="300" height="600"/>

### 💡issue : #5 
